### PR TITLE
Implement support for string representation of classification targets

### DIFF
--- a/src/calibrated_explanations/_VennAbers.py
+++ b/src/calibrated_explanations/_VennAbers.py
@@ -24,6 +24,8 @@ class VennAbers:
     Methods:
         __init__(X_cal, y_cal, learner, bins=None, cprobs=None, difficulty_estimator=None):
             Initializes the VennAbers class with calibration data and model.
+        __convert_targets_to_numeric(y):
+            Converts string/categorical target values to numeric while preserving label mapping.
         __predict_proba_with_difficulty(X, bins=None):
             Predicts probabilities with difficulty adjustment.
         predict(X_test, bins=None):
@@ -35,15 +37,40 @@ class VennAbers:
         is_mondrian() -> bool:
             Returns true if Mondrian categories are used.
     """
+    @staticmethod
+    def __convert_targets_to_numeric(y):
+        """Convert string/categorical targets to numeric values while preserving labels.
+        
+        Args:
+            y (array-like): Array of target values that may be strings or categorical.
+            
+        Returns:
+            tuple:
+                - array-like: Numeric version of the target values
+                - dict or None: Mapping of original labels to numeric values if conversion was needed, None otherwise
+        """
+        if any(isinstance(val, str) for val in y) or any(isinstance(val, (np.str_, np.object_)) for val in y):
+            unique_labels = np.unique(y)
+            label_map = {label: i for i, label in enumerate(unique_labels)}
+            numeric_y = np.array([label_map[label] for label in y])
+            return numeric_y, label_map
+        return y, None
+
     def __init__(self, X_cal, y_cal, learner, bins=None, cprobs=None, difficulty_estimator=None):
+        self.y_cal_numeric, self.label_map = self.__convert_targets_to_numeric(y_cal)
+        self.original_labels = y_cal
+        
         self.de = difficulty_estimator
         self.learner = learner
         self.X_cal = X_cal
-        self.ctargets = y_cal
-        self.__is_multiclass = len(np.unique(y_cal)) > 2
+        self.__is_multiclass = len(np.unique(self.y_cal_numeric)) > 2
+        
         cprobs = self.__predict_proba_with_difficulty(X_cal) if cprobs is None else cprobs
         self.cprobs = cprobs
         self.bins = bins
+        
+        self.ctargets = self.y_cal_numeric
+        
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         if self.is_mondrian():
             self.va = {}
@@ -55,7 +82,9 @@ class VennAbers:
                     tmp_probs[:,1] = cprobs[:,c]
                     for b in np.unique(self.bins):
                         va_class_bin = va.VennAbers()
-                        va_class_bin.fit(tmp_probs[self.bins == b,:], np.multiply(c == self.ctargets[self.bins == b], 1), precision=4)
+                        va_class_bin.fit(tmp_probs[self.bins == b,:], 
+                                       np.multiply(c == self.ctargets[self.bins == b], 1), 
+                                       precision=4)
                         self.va[c][b] = va_class_bin
             else:
                 for b in np.unique(self.bins):


### PR DESCRIPTION
This feature branch implements the support for string representation of classification targets.

This should allow running the example:

```python
from sklearn.datasets import fetch_openml
from sklearn.model_selection import train_test_split

dataset = fetch_openml(name="wine", version=7, as_frame=True)

X = dataset.data.values.astype(float)
y = dataset.target.values

feature_names = dataset.feature_names

X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=2, stratify=y)

X_prop_train, X_cal, y_prop_train, y_cal = train_test_split(X_train, y_train,
                                                            test_size=0.25)
from sklearn.ensemble import RandomForestClassifier

rf = RandomForestClassifier(n_jobs=-1)

rf.fit(X_prop_train, y_prop_train)

from calibrated_explanations import CalibratedExplainer, __version__
print(__version__)

explainer = CalibratedExplainer(rf, X_cal, y_cal, feature_names=feature_names)

factual_explanations = explainer.explain_factual(X_test)
```